### PR TITLE
Simplify basic frac example

### DIFF
--- a/docs/common-techniques.md
+++ b/docs/common-techniques.md
@@ -89,10 +89,7 @@ This method has been around for as long as I have been working on OpenType featu
 feature frac {
     @slash = [slash fraction];
 
-    lookup FractionNumerators {
-        sub @figures by @figuresNumerator;
-    } FractionNumerators;
-
+    sub @figures by @figuresNumerator;
     sub [@slash @figuresDenominator] @figuresNumerator' by @figuresDenominator;
     sub slash by fraction;
 } frac;


### PR DESCRIPTION
When trying to answer a student question, I realized that the FractionNumerators lookup around the first substitution in this example is not needed. Removing it to avoid any further questions! ;-)